### PR TITLE
Fixes for 20.04

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -68,7 +68,7 @@ bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 
 # alt-vim keys to resize panel without prefix
 bind -n M-h resize-pane -L 10

--- a/bootstrap
+++ b/bootstrap
@@ -82,7 +82,7 @@ function ensure_dotfiles() {
 
     echo "Do you want to copy the dotfiles to your home reposory?"
     echo "(This may overwrite some files) Are you sure? (y/[n]) ";
-    read -rn reply
+    read -r reply
     if [[ ${reply} =~ ^[YyZz]$ ]]; then
         rsync --exclude '.git/' \
             --exclude 'bootstrap' \
@@ -121,13 +121,13 @@ function ensure_vim_configuration() {
         sudo apt-get -qq remove vim-tiny
     fi
 
-    if is_installed vim-gnome; then
+    if is_installed vim-gtk3; then
         echo 'vim gnome already installed. Updating vim'
         sudo apt-get update -qq
-        sudo apt-get install --only-upgrade -qq -y vim-gnome
+        sudo apt-get install --only-upgrade -qq -y vim-gtk3
     else
         echo 'Installing vim (huge config)'
-        sudo apt-get install -qq vim-gnome
+        sudo apt-get install -qq vim-gtk3
     fi
     vim +PlugInstall +PlugUpdate +PlugUpgrade +qall
 }
@@ -201,9 +201,8 @@ function ensure_packages() {
         jq
         meld
         nmon
-        python-autopep8
-        python-dev
-        python-yapf
+        python3-autopep8
+        python3-yapf
         python3-dev
         rsync
         shellcheck


### PR DESCRIPTION
There is no vim-gnome in 20.04, but vim-gtk3 should do. Only use the python3 versions of python packages. Escape the \ character for key mappings in .tmux.conf